### PR TITLE
fix: Add missing concurrently dependency

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2"
   }
 }


### PR DESCRIPTION
This commit ensures that the `concurrently` package is correctly listed as a devDependency in the webapp's package.json. This fixes the issue where the `npm run start:dev` command would fail with a 'concurrently: not found' error.

The package is added directly to the package.json and `npm install` is run to ensure it is available for the concurrent execution script.